### PR TITLE
Don't transform underlying datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -616,3 +616,5 @@ MigrationBackup/
 
 # End of https://www.gitignore.io/api/osx,python,pycharm,windows,visualstudio,visualstudiocode
 xarray_fmrc/_version.py
+*.zarr
+*.nc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_stages: [commit, push]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
         exclude: tests/data
@@ -28,27 +28,27 @@ repos:
       - id: blackdoc
 
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         exclude: docs/source/conf.py
         args: [--max-line-length=105]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies: [toml]
         args: ["--profile", "black", "--filter-files"]
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.9.1
     hooks:
       - id: black
         language_version: python3
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.5.1
     hooks:
       - id: mypy
         exclude: docs/source/conf.py
@@ -56,20 +56,20 @@ repos:
         additional_dependencies: [typing_extensions>=4.2.0, types-setuptools]
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
+    rev: v2.2.6
     hooks:
       - id: codespell
         args:
           - --quiet-level=2
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.15.0
     hooks:
       - id: pyupgrade
         args:
           - --py36-plus
 
   - repo: https://github.com/asottile/add-trailing-comma
-    rev: v2.4.0
+    rev: v3.1.0
     hooks:
       - id: add-trailing-comma

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-xarray>=2022.12.0
+xarray>=2022.09.0
 xarray-datatree>=0.0.10
 pandas>=1.4.2

--- a/xarray_fmrc/__init__.py
+++ b/xarray_fmrc/__init__.py
@@ -1,9 +1,9 @@
 """A lightweight way to manage forecast datasets using datatrees"""
 
 from .accessor import FmrcAccessor
-from .build_datatree import from_model_runs
+from .build_datatree import from_dict
 
-__all__ = ["from_model_runs", "FmrcAccessor"]
+__all__ = ["from_dict", "FmrcAccessor"]
 
 
 try:

--- a/xarray_fmrc/accessor.py
+++ b/xarray_fmrc/accessor.py
@@ -10,8 +10,9 @@ import datatree
 import pandas as pd
 import xarray as xr
 
-from .build_datatree import model_run_path
-from .forecast_reference_time import forecast_ref_time
+from . import constants
+from .build_datatree import forecast_reference_time_from_path, model_run_path
+from .forecast_offsets import with_offsets
 
 if TYPE_CHECKING:
     from pandas.core.tools.datetimes import DatetimeScalar
@@ -24,8 +25,23 @@ class FmrcAccessor:
     forecast model run collections
     """
 
+    time_coord = constants.DEFAULT_TIME_COORD
+    group_prefix = constants.DEFAULT_GROUP_PREFIX
+    time_format = constants.DEFAULT_TIME_FORMAT
+    forecast_coords = constants.DEFAULT_FORECAST_COORDS
+
     def __init__(self, datatree_obj: datatree.DataTree):
-        self.datatree_obj = datatree_obj
+        """Set the internal datatree object, and if any of the top level attrs are set,
+        override the defaults"""
+        self._datatree_obj = datatree_obj
+
+        for key, value in constants.DT_ATTRS.items():
+            if value in datatree_obj.attrs:
+                setattr(self, key, datatree_obj.attrs[value])
+
+    def model_run_path(self, from_dt: "DatetimeScalar") -> str:
+        """Return the model run path given a datetime-like input"""
+        return model_run_path(from_dt, self.group_prefix, self.time_format)
 
     def model_run(self, dt: "DatetimeScalar") -> xr.Dataset:
         """Get the dataset for a single model run
@@ -33,9 +49,29 @@ class FmrcAccessor:
         Accepts valid to `pd.to_datetime()`
         https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.to_datetime.html
         """
-        path = model_run_path(dt)
+        path = self.model_run_path(dt)
 
-        return self.datatree_obj[path].ds
+        return self._datatree_obj[path].ds
+
+    def forecast_reference_time_from_path(self, path: str) -> pd.Timestamp:
+        """Return the forecast reference time for a given path"""
+        return forecast_reference_time_from_path(
+            path,
+            self.group_prefix,
+            self.time_format,
+        )
+
+    def forecast_reference_times(self):
+        """Get the forecast reference times based on the pattern in the path"""
+        times = {}
+
+        for group in self._datatree_obj.groups:
+            try:
+                times[group] = self.forecast_reference_time_from_path(group)
+            except ValueError:
+                pass
+
+        return times
 
     def constant_forecast(self, dt: "DatetimeScalar") -> xr.Dataset:
         """
@@ -47,10 +83,18 @@ class FmrcAccessor:
         datetime = pd.to_datetime(dt)
         filtered_ds = []
 
-        for child in self.datatree_obj["model_run"].children.values():
+        for t in sorted(self.forecast_reference_times().values()):
+            ds = self.model_run(t)
+
             try:
-                selected = child.ds.sel(time=datetime)
-                filtered_ds.append(selected)
+                ds = ds.sel({self.time_coord: datetime})
+                ds = (
+                    ds.drop_indexes(self.forecast_coords)
+                    .reset_coords(self.forecast_coords)
+                    .squeeze()
+                )
+                ds["forecast_reference_time"] = t
+                filtered_ds.append(ds)
             except KeyError:
                 pass
 
@@ -69,48 +113,54 @@ class FmrcAccessor:
 
         filtered_ds = []
 
-        for child in self.datatree_obj["model_run"].children.values():
+        for t in sorted(self.forecast_reference_times().values()):
+            ds = self.model_run(t)
+            ds = (
+                ds.drop_indexes(self.forecast_coords)
+                .reset_coords(self.forecast_coords)
+                .squeeze()
+            )
+            ds["forecast_reference_time"] = t
+            ds = with_offsets(ds, self.time_coord)
+
             try:
-                selected = child.ds.sel(forecast_offset=timedelta)
-                filtered_ds.append(selected)
+                ds = ds.sel(forecast_offset=timedelta)
+
+                filtered_ds.append(ds)
             except KeyError:
                 pass
 
-        combined = xr.concat(filtered_ds, "time")
-        combined = combined.sortby("time")
+        combined = xr.concat(filtered_ds, self.time_coord)
+        combined = combined.sortby(self.time_coord)
         return combined
 
     def best(self) -> xr.Dataset:
         """
         Returns a dataset with the best possible forecast data.
         """
-        forecast_coords = ["forecast_reference_time", "forecast_offset"]
-
-        forecast_times = self.datatree_obj["forecast_reference_time"].sortby(
-            "forecast_reference_time",
-            ascending=False,
-        )
+        forecast_times = sorted(self.forecast_reference_times().values(), reverse=True)
 
         dataset: xr.Dataset = None
 
         for t in forecast_times:
-            ft = forecast_ref_time(t)
-
-            ds = self.datatree_obj[f"model_run/{ft.isoformat()}"].ds
+            ds = self.model_run(t)
             ds = (
-                ds.drop_indexes(forecast_coords).reset_coords(forecast_coords).squeeze()
+                ds.drop_indexes(self.forecast_coords)
+                .reset_coords(self.forecast_coords)
+                .squeeze()
             )
+            ds["forecast_reference_time"] = t
 
             if dataset is None:
                 dataset = ds
             else:
-                existing_times = set(dataset["time"].to_numpy())
-                new_times = set(ds["time"].to_numpy())
+                existing_times = set(dataset[self.time_coord].to_numpy())
+                new_times = set(ds[self.time_coord].to_numpy())
                 unique_times = new_times.difference(existing_times)
 
-                ds = ds.where(ds["time"].isin(list(unique_times)))
+                ds = ds.where(ds[self.time_coord].isin(list(unique_times)))
 
-                dataset = xr.concat([dataset, ds], "time")
+                dataset = xr.concat([dataset, ds], self.time_coord)
 
-        dataset = dataset.sortby("time")
+        dataset = dataset.sortby(self.time_coord)
         return dataset

--- a/xarray_fmrc/constants.py
+++ b/xarray_fmrc/constants.py
@@ -1,0 +1,22 @@
+"""
+Constant and default values for attributes and other configuration of
+xarray_fmrc.
+"""
+
+DEFAULT_GROUP_PREFIX = "forecast_reference_time/"
+DEFAULT_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
+DEFAULT_TIME_COORD = "time"
+DEFAULT_FORECAST_COORDS = ["forecast_reference_time", "forecast_offset"]
+
+DT_ATTR_GROUP_PREFIX = "xarray_fmrc_group_prefix"
+DT_ATTR_TIME_FORMAT = "xarray_fmrc_time_format"
+DT_ATTR_TIME_COORD = "xarray_fmrc_time_coord"
+DT_ATTR_FORECAST_COORDS = "xarray_fmrc_forecast_coords"
+
+
+DT_ATTRS = {
+    "group_prefix": DT_ATTR_GROUP_PREFIX,
+    "time_format": DT_ATTR_TIME_FORMAT,
+    "time_coord": DT_ATTR_TIME_COORD,
+    "forecast_coords": DT_ATTR_FORECAST_COORDS,
+}

--- a/xarray_fmrc/forecast_offsets.py
+++ b/xarray_fmrc/forecast_offsets.py
@@ -4,21 +4,28 @@ Forecast offset handling
 import pandas as pd
 import xarray as xr
 
+from . import constants
 from .forecast_reference_time import forecast_ref_time
 
 
-def calc_offsets(ds: xr.Dataset) -> pd.TimedeltaIndex:
+def calc_offsets(
+    ds: xr.Dataset,
+    time_coord: str = constants.DEFAULT_TIME_COORD,
+) -> pd.TimedeltaIndex:
     """Calculate forecast offsets in relation to reference time"""
     forecast_time = forecast_ref_time(ds)
-    offsets = pd.to_datetime(ds["time"]) - forecast_time
+    offsets = pd.to_datetime(ds[time_coord]) - forecast_time
 
     return offsets
 
 
-def with_offsets(ds: xr.Dataset) -> xr.Dataset:
+def with_offsets(
+    ds: xr.Dataset,
+    time_coord: str = constants.DEFAULT_TIME_COORD,
+) -> xr.Dataset:
     """Add forecast offset as a dimensionless coordinate"""
     offsets = calc_offsets(ds)
 
-    ds = ds.assign_coords({"forecast_offset": ("time", offsets)})
+    ds = ds.assign_coords({"forecast_offset": (time_coord, offsets)})
     ds = ds.set_xindex("forecast_offset")
     return ds


### PR DESCRIPTION
## Description

Refactored xarray_fmrc to no longer depend on some geometry of underlying datasets. Instead it should be able to get more information from the structure of the datatree (forecast_reference_time). If more tweaking is needed, things like the time coord, time format, group_prefix, and forecast_coords can be overridden on the accessor, and it will attempt to those configs from top level datatree attributes.

Additionally it should be possible to set `model_run_path` and `forecast_reference_time_from_path` to more fully tweak how xarray_fmrc interprets the structure of the datatree.

## Related Issue

Closes #10
Closes #8

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/abkfenris/xarray-fmrc/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/abkfenris/xarray-fmrc/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
