### PR TITLE
Fix issues with offset and best accessors

### DIFF
--- a/xarray_fmrc/accessor.py
+++ b/xarray_fmrc/accessor.py
@@ -158,7 +158,7 @@ class FmrcAccessor:
                 new_times = set(ds[self.time_coord].to_numpy())
                 unique_times = new_times.difference(existing_times)
 
-                ds = ds.where(ds[self.time_coord].isin(list(unique_times)))
+                ds = ds.sel({self.time_coord: sorted(unique_times)})
 
                 dataset = xr.concat([dataset, ds], self.time_coord)
 

--- a/xarray_fmrc/forecast_offsets.py
+++ b/xarray_fmrc/forecast_offsets.py
@@ -24,7 +24,7 @@ def with_offsets(
     time_coord: str = constants.DEFAULT_TIME_COORD,
 ) -> xr.Dataset:
     """Add forecast offset as a dimensionless coordinate"""
-    offsets = calc_offsets(ds)
+    offsets = calc_offsets(ds, time_coord=time_coord)
 
     ds = ds.assign_coords({"forecast_offset": (time_coord, offsets)})
     ds = ds.set_xindex("forecast_offset")


### PR DESCRIPTION
## Description

Fixes two issues
1. In constant_offset the with_offsets method must pass optional argument time_coord to calc_offsets
2. In best the ds.where only masks the unique times. We need to ds.sel instead.

## Related Issue

NA

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

I ran `black .`
Not sure you have the other pieces in place for this yet?

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/abkfenris/xarray-fmrc/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/abkfenris/xarray-fmrc/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
